### PR TITLE
fix: disable dark mode on admin sidebar

### DIFF
--- a/resources/views/admin/_layouts/navigation.blade.php
+++ b/resources/views/admin/_layouts/navigation.blade.php
@@ -133,8 +133,8 @@
     </div>
 </nav>
 
-<aside id="logo-sidebar" class="fixed top-0 mt-16 left-0 z-20 w-56 h-screen pt-2 transition-transform -translate-x-full bg-white border-r border-gray-200 md:translate-x-0 dark:bg-gray-800 dark:border-gray-700" aria-label="Sidebar">
-    <div class="h-full pb-4 overflow-y-auto bg-white dark:bg-gray-800">
+<aside id="logo-sidebar" class="fixed top-0 mt-16 left-0 z-20 w-56 h-screen pt-2 transition-transform -translate-x-full bg-white border-r border-gray-200 md:translate-x-0" aria-label="Sidebar">
+    <div class="h-full pb-4 overflow-y-auto bg-white">
        <ul class="space-y-2 font-medium">
 
             @foreach( $menus as $menu )


### PR DESCRIPTION
### QA Step:

- changes your desktop or browser theme to dark mode.
- login or open admin page.
- check if the sidebar looks normal or not.